### PR TITLE
fixes issue starting app when packages refers to npm-container

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,4 +26,4 @@ email
 
 #ssnpm-container
 
-npm-container
+#npm-container


### PR DESCRIPTION
I believe this should fix the following error that is happening on app startup:

[[[[[ /opt/xpenz ]]]]]

=> Started proxy.
=> Started MongoDB.
=> Errors prevented startup:

   While selecting package versions:
   error: unknown package: npm-container

=> Your application has errors. Waiting for file change.
